### PR TITLE
Parameterize Openstack Taster

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,9 +14,12 @@ Metrics/MethodLength:
 Metrics/ClassLength:
   Enabled: false
 
-
-Style/ParameterLists:
+Metrics/BlockLength:
   Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
 
 Style/IfUnlessModifier:
   MaxLineLength: 120

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org' do
   gem 'fog'
-  gem 'net-ssh'
   gem 'inspec'
+  gem 'net-ssh'
   gem 'optparse'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ source 'https://rubygems.org' do
   gem 'fog'
   gem 'net-ssh'
   gem 'inspec'
+  gem 'optparse'
 end

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -4,7 +4,7 @@
 require 'optparse'
 
 suites = {
-  'security' => 'Runs the security test suite', 
+  'security' => 'Runs the security test suite',
   'volumes' => 'Runs the volume test suite'
 }
 settings = {}
@@ -12,11 +12,11 @@ settings = {}
 ARGV << '-h' if ARGV.empty?
 
 parser = OptionParser.new do |opts|
-  opts.banner = "Usage: openstack_taster <test_suite> <image_name> <option>\n" + \
-                "   or: openstack_taster <test_suite>\n" + \
-                "   or: openstack_taster <option>"
-  opts.separator("")
-  opts.separator("Available Arguments:")
+  opts.banner = "'Usage: openstack_taster <test_suite> <image_name> <option>\n" \
+                "   or: openstack_taster <test_suite>\n" \
+                '   or: openstack_taster <option>'
+  opts.separator('')
+  opts.separator('Available Arguments:')
   opts.on('-c', '--create-image', 'Create image upon test failure.') do
     settings[:create] = true
   end
@@ -24,8 +24,8 @@ parser = OptionParser.new do |opts|
     puts opts
     settings[:exit] = true
   end
-  opts.separator("")
-  opts.separator("Test Suites:")
+  opts.separator('')
+  opts.separator('Test Suites:')
   suites.each do |suite, desc|
     opts.separator("    #{suite}\t\t#{desc}")
   end
@@ -37,8 +37,8 @@ rescue OptionParser::InvalidOption => io
   puts io.message
   puts parser
   exit 1
-rescue Exception => e
-  puts "Argument parsing failed:"
+rescue StandardError => e
+  puts 'Argument parsing failed:'
   puts e.message
   puts e.backtrace
   exit 1
@@ -52,13 +52,13 @@ begin
     image_name = params[0]
     suites.each_key { |suite| settings[suite.to_sym] = true }
   when 2
-    raise "#{params[0]} is not a test suite!" if ! suites.include? params[0]
+    raise "#{params[0]} is not a test suite!" unless suites.include? params[0]
     image_name = params[1]
     settings[params[0].to_sym] = true
   else
     raise '"' + params.join(' ') + '" is not the correct format!'
   end
-rescue Exception => e
+rescue StandardError => e
   puts e.message
   puts
   puts parser
@@ -94,6 +94,6 @@ image   = Fog::Image::OpenStack.new(OPENSTACK_CREDS)
 network = Fog::Network::OpenStack.new(OPENSTACK_CREDS)
 
 exit OpenStackTaster.new(
-       compute, volume, image, network,
-       SSH_KEYS, LOG_DIR
-     ).taste(image_name, settings)
+  compute, volume, image, network,
+  SSH_KEYS, LOG_DIR
+).taste(image_name, settings)

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$test_volumes = true
-$test_security = true
+settings = {
+  'volumes': true,
+  'security': true
+}
 
 def print_usage(exit_val = 0)
     puts "Usage: openstack_taster <test_suite> <image_name>"
@@ -30,9 +32,9 @@ if ARGV.length == 1
 elsif ARGV.length == 2
   case ARGV[0]
   when 'volume'
-    $test_security = false
+    settings[:security] = false
   when 'security'
-    $test_volumes = false
+    settings[:volumes] = false
   when 'all'
   else
     puts "#{ARGV[0]} is not a valid test suite!"
@@ -74,4 +76,4 @@ network = Fog::Network::OpenStack.new(OPENSTACK_CREDS)
 OpenStackTaster.new(
   compute, volume, image, network,
   SSH_KEYS, LOG_DIR
-).taste ARGV[1] 
+).taste(ARGV[1], settings)

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 # frozen_string_literal: true
+abort("Usage: openstack_taster <image_name>") if ARGV.length != 1
 
 require 'fog/openstack'
 require 'openstack_taster'
@@ -33,4 +34,4 @@ network = Fog::Network::OpenStack.new(OPENSTACK_CREDS)
 OpenStackTaster.new(
   compute, volume, image, network,
   SSH_KEYS, LOG_DIR
-).taste_all
+).taste ARGV[0] 

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -35,6 +35,7 @@ begin
   params = parser.parse!
 rescue OptionParser::InvalidOption => io
   puts io.message
+  puts
   puts parser
   exit 1
 rescue StandardError => e
@@ -56,7 +57,7 @@ begin
     image_name = params[1]
     settings[params[0].to_sym] = true
   else
-    raise '"' + params.join(' ') + '" is not the correct format!'
+    raise "'#{params.join(' ')}' is not the correct format!"
   end
 rescue StandardError => e
   puts e.message

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -22,7 +22,7 @@ parser = OptionParser.new do |opts|
   end
   opts.on('-h', '--help', 'Print usage information.') do
     puts opts
-    exit
+    settings[:exit] = true
   end
   opts.separator("")
   opts.separator("Test Suites:")
@@ -38,9 +38,13 @@ rescue OptionParser::InvalidOption => io
   puts parser
   exit 1
 rescue Exception => e
-  puts "Argument parsing failed: #{e.message} \n #{e.backtrace}"
+  puts "Argument parsing failed:"
+  puts e.message
+  puts e.backtrace
   exit 1
 end
+
+exit if settings[:exit] # exit inside OptionParser causes problems.
 
 begin
   case params.length

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -15,7 +15,7 @@ def print_usage(exit_val = 0)
     puts
     puts "Test Suites:"
     puts "\tall\t\tRuns all test suites."
-    puts "\tvolume\t\tRuns the volume test suite."
+    puts "\tvolumes\t\tRuns the volume test suite."
     puts "\tsecurity\tRuns the security test suite."
     exit(exit_val)
 end
@@ -31,7 +31,7 @@ if ARGV.length == 1
   end
 elsif ARGV.length == 2
   case ARGV[0]
-  when 'volume'
+  when 'volumes'
     settings[:security] = false
   when 'security'
     settings[:volumes] = false

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -4,8 +4,8 @@
 require 'optparse'
 
 suites = {
-  'security' => 'Runs the volume test suite', 
-  'volumes' => 'Runs the security test suite'
+  'security' => 'Runs the security test suite', 
+  'volumes' => 'Runs the volume test suite'
 }
 settings = {}
 
@@ -17,7 +17,7 @@ parser = OptionParser.new do |opts|
                 "   or: openstack_taster <option>"
   opts.separator("")
   opts.separator("Available Arguments:")
-  opts.on('-c', '--create-image', 'Create image upon test failure. Used when testing.') do
+  opts.on('-c', '--create-image', 'Create image upon test failure.') do
     settings[:create] = true
   end
   opts.on('-h', '--help', 'Print usage information.') do

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -1,21 +1,46 @@
 #!/usr/bin/env ruby
-
-def print_usage
-    puts "Usage: openstack_taster <image_name>"
-    puts "   or: openstack_taster <option>"
-    puts "Available arguments:"
-    puts "\t-h, --help\t Print"
-    exit(0)
-end
 # frozen_string_literal: true
-print_usage if ARGV.length == 0
 
-if ARGV[0] =~ /^-/
-  if ARGV[0] =~ /^-(h|-help)$/
+$test_volumes = true
+$test_security = true
+
+def print_usage(exit_val = 0)
+    puts "Usage: openstack_taster <test_suite> <image_name>"
+    puts "   or: openstack_taster <option>"
+    puts
+    puts "Available arguments:"
+    puts "\t-h, --help\tPrint usage information"
+    puts
+    puts "Test Suites:"
+    puts "\tall\t\tRuns all test suites."
+    puts "\tvolume\t\tRuns the volume test suite."
+    puts "\tsecurity\tRuns the security test suite."
+    exit(exit_val)
+end
+
+if ARGV.length == 1
+  case ARGV[0]
+  when '-h', '--help'
     print_usage
   else
-    print_usage
+    puts "#{ARGV[0]} is not a valid flag!"
+    puts
+    print_usage 1
   end
+elsif ARGV.length == 2
+  case ARGV[0]
+  when 'volume'
+    $test_security = false
+  when 'security'
+    $test_volumes = false
+  when 'all'
+  else
+    puts "#{ARGV[0]} is not a valid test suite!"
+    puts
+    print_usage 1
+  end
+else
+  print_usage 1
 end
 
 require 'fog/openstack'
@@ -49,4 +74,4 @@ network = Fog::Network::OpenStack.new(OPENSTACK_CREDS)
 OpenStackTaster.new(
   compute, volume, image, network,
   SSH_KEYS, LOG_DIR
-).taste ARGV[0] 
+).taste ARGV[1] 

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -1,48 +1,55 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-settings = {
-  'volumes': true,
-  'security': true
-}
+require 'optparse'
 
-def print_usage(exit_val = 0)
-    puts "Usage: openstack_taster <test_suite> <image_name>"
-    puts "   or: openstack_taster <option>"
-    puts
-    puts "Available arguments:"
-    puts "\t-h, --help\tPrint usage information"
-    puts
-    puts "Test Suites:"
-    puts "\tall\t\tRuns all test suites."
-    puts "\tvolumes\t\tRuns the volume test suite."
-    puts "\tsecurity\tRuns the security test suite."
-    exit(exit_val)
+suites = {
+  'security' => 'Runs the volume test suite', 
+  'volumes' => 'Runs the security test suite'
+}
+settings = {}
+
+ARGV << '-h' if ARGV.empty?
+
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: openstack_taster <test_suite> <image_name> <option>\n" + \
+                "   or: openstack_taster <test_suite>\n" + \
+                "   or: openstack_taster <option>"
+  opts.separator("")
+  opts.separator("Available Arguments:")
+  opts.on('-c', '--create-image', 'Create image upon test failure. Used when testing.') do
+    settings[:create] = true
+  end
+  opts.on('-h', '--help', 'Print usage information.') do
+    puts opts
+    exit
+  end
+  opts.separator("")
+  opts.separator("Test Suites:")
+  suites.each do |suite, desc|
+    opts.separator("    #{suite}\t\t#{desc}")
+  end
 end
 
-if ARGV.length == 1
-  case ARGV[0]
-  when '-h', '--help'
-    print_usage
+params = parser.parse!
+
+begin
+  case params.length
+  when 1
+    image_name = params[0]
+    suites.each_key { |suite| settings[suite.to_sym] = true }
+  when 2
+    raise "#{params[0]} is not a test suite!" if ! suites.include? params[0]
+    image_name = params[1]
+    settings[params[0].to_sym] = true
   else
-    puts "#{ARGV[0]} is not a valid flag!"
-    puts
-    print_usage 1
+    raise '"' + params.join(' ') + '" is not the correct format!'
   end
-elsif ARGV.length == 2
-  case ARGV[0]
-  when 'volumes'
-    settings[:security] = false
-  when 'security'
-    settings[:volumes] = false
-  when 'all'
-  else
-    puts "#{ARGV[0]} is not a valid test suite!"
-    puts
-    print_usage 1
-  end
-else
-  print_usage 1
+rescue Exception => e
+  puts e.message
+  puts
+  puts parser
+  exit(1)
 end
 
 require 'fog/openstack'

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -31,7 +31,16 @@ parser = OptionParser.new do |opts|
   end
 end
 
-params = parser.parse!
+begin
+  params = parser.parse!
+rescue OptionParser::InvalidOption => io
+  puts io.message
+  puts parser
+  exit 1
+rescue Exception => e
+  puts "Argument parsing failed: #{e.message} \n #{e.backtrace}"
+  exit 1
+end
 
 begin
   case params.length

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -1,7 +1,22 @@
 #!/usr/bin/env ruby
 
+def print_usage
+    puts "Usage: openstack_taster <image_name>"
+    puts "   or: openstack_taster <option>"
+    puts "Available arguments:"
+    puts "\t-h, --help\t Print"
+    exit(0)
+end
 # frozen_string_literal: true
-abort("Usage: openstack_taster <image_name>") if ARGV.length != 1
+print_usage if ARGV.length == 0
+
+if ARGV[0] =~ /^-/
+  if ARGV[0] =~ /^-(h|-help)$/
+    print_usage
+  else
+    print_usage
+  end
+end
 
 require 'fog/openstack'
 require 'openstack_taster'

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -80,7 +80,7 @@ volume  = Fog::Volume::OpenStack.new(OPENSTACK_CREDS)
 image   = Fog::Image::OpenStack.new(OPENSTACK_CREDS)
 network = Fog::Network::OpenStack.new(OPENSTACK_CREDS)
 
-OpenStackTaster.new(
-  compute, volume, image, network,
-  SSH_KEYS, LOG_DIR
-).taste(ARGV[1], settings)
+exit OpenStackTaster.new(
+       compute, volume, image, network,
+       SSH_KEYS, LOG_DIR
+     ).taste(image_name, settings)

--- a/lib/openstack_taster.rb
+++ b/lib/openstack_taster.rb
@@ -56,6 +56,10 @@ class OpenStackTaster
     image  = @compute_service.images # FIXME: Images over compute service is deprecated
       .select { |i| i.name == image_name }.first
 
+    if image.nil?
+      abort("#{image_name} is not an available image.")
+    end
+
     distro_user_name = image.name.downcase.gsub(/[^a-z].*$/, '') # truncate downcased name at first non-alpha char
     distro_arch = image.name.downcase.slice(-2, 2)
     instance_name = format(
@@ -124,7 +128,7 @@ class OpenStackTaster
       puts "Destroying instance for session #{@session_id}.\n\n"
       instance.destroy
     end
-    return false
+    false
   end
 
   def test_security(instance, username)

--- a/lib/openstack_taster.rb
+++ b/lib/openstack_taster.rb
@@ -178,9 +178,9 @@ class OpenStackTaster
 
     if runner.report[:controls].any?{|test| test[:status] == 'failed'}
       error_log(instance.logger, 'warn', 'Image failed security test suite')
-      false
+      return false
     end
-    true
+    return true
   end
 
   def error_log(logger, level, message, dup_stdout = false, context = nil)

--- a/lib/openstack_taster.rb
+++ b/lib/openstack_taster.rb
@@ -112,11 +112,11 @@ class OpenStackTaster
     return_values.push taste_security(instance, distro_user_name) if settings[:security]
     return_values.push taste_volumes(instance, distro_user_name) if settings[:volumes]
 
-    if settings[:create] && return_values.include?(false)
+    if settings[:create] && !return_values.all?
       error_log(instance.logger, 'info', "Tests failed for instance '#{instance.id}'. Creating image...", true)
       create_image(instance) # Create image here since it is destroyed before scope returns to taste function
     end
-    return !return_values.include?(false)
+    return return_values.all?
   rescue Fog::Errors::TimeoutError
     puts 'Instance creation timed out.'
     error_log(instance.logger, 'error', "Instance fault: #{instance.fault}")

--- a/lib/openstack_taster.rb
+++ b/lib/openstack_taster.rb
@@ -111,10 +111,11 @@ class OpenStackTaster
   end
 
   def test(instance, distro_user_name)
-      return (
-        test_security(instance, distro_user_name) &&
-        test_volumes(instance, distro_user_name)
-      )
+    #binding.pry
+    return (
+      (test_security(instance, distro_user_name) if $test_security) &&
+      (test_volumes(instance, distro_user_name) if $test_volumes)
+    )
   rescue Fog::Errors::TimeoutError
     puts 'Instance creation timed out.'
     error_log(instance.logger, 'error', "Instance fault: #{instance.fault}")
@@ -128,7 +129,7 @@ class OpenStackTaster
       puts "Destroying instance for session #{@session_id}.\n\n"
       instance.destroy
     end
-    false
+    return false
   end
 
   def test_security(instance, username)

--- a/lib/openstack_taster.rb
+++ b/lib/openstack_taster.rb
@@ -52,7 +52,7 @@ class OpenStackTaster
       .select { |network| network.name == INSTANCE_NETWORK_NAME }.first
   end
 
-  def taste(image_name)
+  def taste(image_name, settings)
     image  = @compute_service.images # FIXME: Images over compute service is deprecated
       .select { |i| i.name == image_name }.first
 
@@ -107,15 +107,13 @@ class OpenStackTaster
 
     error_log(instance.logger, 'info', "Testing for instance '#{instance.id}'.", true)
 
-    return test(instance, distro_user_name) 
+    return test(instance, distro_user_name, settings) 
   end
 
-  def test(instance, distro_user_name)
-    #binding.pry
-    return (
-      (test_security(instance, distro_user_name) if $test_security) &&
-      (test_volumes(instance, distro_user_name) if $test_volumes)
-    )
+  def test(instance, distro_user_name, settings)
+    return false unless test_security(instance, distro_user_name) if settings[:security]
+    return false unless test_volumes(instance, distro_user_name) if settings[:volumes]
+    return true
   rescue Fog::Errors::TimeoutError
     puts 'Instance creation timed out.'
     error_log(instance.logger, 'error', "Instance fault: #{instance.fault}")

--- a/lib/openstack_taster.rb
+++ b/lib/openstack_taster.rb
@@ -111,9 +111,10 @@ class OpenStackTaster
   end
 
   def test(instance, distro_user_name, settings)
-    return false unless test_security(instance, distro_user_name) if settings[:security]
-    return false unless test_volumes(instance, distro_user_name) if settings[:volumes]
-    return true
+    return_values = []
+    return_values.push test_security(instance, distro_user_name) if settings[:security]
+    return_values.push test_volumes(instance, distro_user_name) if settings[:volumes]
+    return return_values.include? false
   rescue Fog::Errors::TimeoutError
     puts 'Instance creation timed out.'
     error_log(instance.logger, 'error', "Instance fault: #{instance.fault}")

--- a/lib/openstack_taster.rb
+++ b/lib/openstack_taster.rb
@@ -112,11 +112,11 @@ class OpenStackTaster
     return_values.push taste_security(instance, distro_user_name) if settings[:security]
     return_values.push taste_volumes(instance, distro_user_name) if settings[:volumes]
 
-    if settings[:create] && return_values.include? false
+    if settings[:create] && return_values.include?(false)
       error_log(instance.logger, 'info', "Tests failed for instance '#{instance.id}'. Creating image...", true)
       create_image(instance) # Create image here since it is destroyed before scope returns to taste function
     end
-    return !return_values.include? false
+    return !return_values.include?(false)
   rescue Fog::Errors::TimeoutError
     puts 'Instance creation timed out.'
     error_log(instance.logger, 'error', "Instance fault: #{instance.fault}")

--- a/openstack_taster.gemspec
+++ b/openstack_taster.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.name        = 'openstack_taster'
   spec.version     = '0.0.1'
   spec.summary     = "Taste all of the OpenStack's basic functionality for an image"
-  spec.description = "Tastes images on an OpenStack deployment for security and basic usability"
+  spec.description = 'Tastes images on an OpenStack deployment for security and basic usability'
   spec.author      = ['OSU Open Source Lab']
   spec.email       = 'support@osuosl.org'
   spec.licenses    = ['Apache-2.0']
@@ -13,9 +13,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'fog', '~> 1.40.0'
   spec.add_runtime_dependency 'net-ssh', '~> 3.2.0'
   spec.executables = 'openstack_taster'
-  spec.files       = ['lib/openstack_taster.rb',
-                      'bin/openstack_taster',
-                      'tests/inspec.yml',
-                      'tests/controls/security_test.rb'
-                     ]
+  spec.files       = [
+    'lib/openstack_taster.rb',
+    'bin/openstack_taster',
+    'tests/inspec.yml',
+    'tests/controls/security_test.rb'
+  ]
 end

--- a/tests/controls/security_test.rb
+++ b/tests/controls/security_test.rb
@@ -1,7 +1,8 @@
-control "security-1.0" do
+# frozen_string_literal: true
+control 'security-1.0' do
   impact 1.0
-  title "Openstack Image Security Test"
-  desc "Tests the security of images used for Openstack."
+  title 'Openstack Image Security Test'
+  desc 'Tests the security of images used for Openstack.'
 
   username = user.username
 
@@ -16,37 +17,35 @@ control "security-1.0" do
     let(:resource) { command('sudo sshd -T') }
 
     it 'should not permit root login' do
-      expect(resource.stdout).to cmp /^PermitRootLogin no/i
+      expect(resource.stdout).to cmp(/^PermitRootLogin no/i)
     end
 
     it 'should not permit password authentication' do
-      expect(resource.stdout).to cmp /^PasswordAuthentication no/i
+      expect(resource.stdout).to cmp(/^PasswordAuthentication no/i)
     end
 
     it 'should not permit challenge response authentication' do
-      expect(resource.stdout).to cmp /^ChallengeResponseAuthentication no/i
+      expect(resource.stdout).to cmp(/^ChallengeResponseAuthentication no/i)
     end
     it 'should not permit keyboard interactive authentication' do
-      expect(resource.stdout).to cmp /^KbdInteractiveAuthentication no/i
+      expect(resource.stdout).to cmp(/^KbdInteractiveAuthentication no/i)
     end
   end
 
-=begin
-  Our version of inspec does not give us a warning about the list matcher,
-  but in version 2.0 of inspec this will be removed.
-  This tests the number of instances of sshd on the system.
-=end
+  # Our version of inspec does not give us a warning about the list matcher,
+  # but in version 2.0 of inspec this will be removed.
+  # This tests the number of instances of sshd on the system.
   describe processes('sshd') do
-    its('list.length') { should eq 1 } 
+    its('list.length') { should eq 1 }
   end
 
   describe.one do
     describe user(username) do
       its('groups') { should eq %w(root wheel sudo) }
     end
-  
+
     describe command('sudo -U ' + username + ' -l') do
-      its('stdout') { should cmp /\(ALL\) ((NO)*PASSWD)*: ALL/ }
+      its('stdout') { should cmp(/\(ALL\) ((NO)*PASSWD)*: ALL/) }
     end
   end
 end


### PR DESCRIPTION
This PR changes openstack taster so that it takes image names as a parameter.
Taster can now only operate on one image at a time, but can choose which test suites to use in addition.
There is a help flag as well as a flag to create the image upon test failure.