### PR TITLE
No longer crashes when volumes host goes down.

### DIFF
--- a/lib/openstack_taster.rb
+++ b/lib/openstack_taster.rb
@@ -333,9 +333,14 @@ class OpenStackTaster
     error_log(instance.logger, 'info', "Sleeping #{TIMEOUT_VOLUME_PERSIST} seconds for attachment persistance...", true)
     sleep TIMEOUT_VOLUME_PERSIST
 
-    return true if instance.instance_eval(&volume_attached)
+    # In the off chance that the volume host goes down, catch it.
+    if instance.instance_eval(&volume_attached)
+      return true if volume.attachments.first
+      error_log(instance.logger, 'error', "Failed to attach '#{volume.name}': Volume host might be down.", true)
+    else
+      error_log(instance.logger, 'error', "Failed to attach '#{volume.name}': Volume was unexpectedly detached.", true)
+    end
 
-    error_log(instance.logger, 'error', "Failed to attach '#{volume.name}': Volume was unexpectedly detached.", true)
     false
   rescue Excon::Error => e
     puts 'Error attaching volume, check log for details.'


### PR DESCRIPTION
Fixes issue #36. If a host was down, volume_service still recognizes the volumes on it. It shows that the volume is attached from the instance side, but not from the volume's side. So we test that both are working before accepting it.