### PR TITLE
Check for any ports listening other than ssh

### DIFF
--- a/lib/openstack_taster.rb
+++ b/lib/openstack_taster.rb
@@ -9,7 +9,7 @@ require 'inspec'
 
 # @author Andrew Tolvstad, Samarendra Hedaoo, Cody Holliday
 class OpenStackTaster
-  INSTANCE_FLAVOR_NAME = 'm1.small'
+  INSTANCE_FLAVOR_NAME = 'm1.tiny'
   INSTANCE_NETWORK_NAME = 'public'
   INSTANCE_NAME_PREFIX = 'taster'
   INSTANCE_VOLUME_MOUNT_POINT = '/mnt/taster_volume'

--- a/lib/openstack_taster.rb
+++ b/lib/openstack_taster.rb
@@ -155,6 +155,7 @@ class OpenStackTaster
       'host' => instance.addresses['public'].first['addr'],
       'port' => 22,
       'user' => username,
+      'sudo' => true,
       'keys_only' => true,
       'key_files' => @ssh_private_key,
       'logger' => instance.logger

--- a/openstack_taster.gemspec
+++ b/openstack_taster.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = 'openstack_taster'
-  spec.version     = '1.0.1'
+  spec.version     = '1.0.2'
   spec.summary     = "Taste all of the OpenStack's basic functionality for an image"
   spec.description = 'Tastes images on an OpenStack deployment for security and basic usability.'
   spec.author      = ['OSU Open Source Lab']

--- a/tests/controls/security_test.rb
+++ b/tests/controls/security_test.rb
@@ -60,4 +60,14 @@ control 'security-1.0' do
       its('stdout') { should cmp(/\(ALL\) ((NO)*PASSWD)*: ALL/) }
     end
   end
+
+  # ssh should be the only thing listening
+  describe port.where { protocol =~ /tcp/ && port != 22 } do
+    it { should_not be_listening }
+  end
+
+  # It's OK if dhclient is listening
+  describe port.where { protocol =~ /udp/ && port != 68 && process != 'dhclient' } do
+    it { should_not be_listening }
+  end
 end

--- a/tests/controls/security_test.rb
+++ b/tests/controls/security_test.rb
@@ -4,7 +4,7 @@ control 'security-1.0' do
   title 'Openstack Image Security Test'
   desc 'Tests the security of images used for Openstack.'
 
-  username = user.username
+  username = os.name
 
   describe 'saved sshd config' do
     let(:resource) { command('sudo cat /etc/ssh/sshd_config') }

--- a/tests/inspec.yml
+++ b/tests/inspec.yml
@@ -3,5 +3,5 @@ title: OpenPower Security Test Suite
 maintainer: OSU Open Source Lab
 copyright: Oregon State University
 license: Apache License, Version 2.0
-summary: Verify that an image has correctly configured security settings. 
-version: 1.0.0
+summary: Verify that an image has correctly configured security settings.
+version: 1.0.2


### PR DESCRIPTION
We shouldn't have anything listening on a port other than 22. This should catch
more open services we shouldn't have.