### PR TITLE
Grab the openstack network name from the environment settings.

### DIFF
--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -95,7 +95,7 @@ volume  = Fog::Volume::OpenStack.new(OPENSTACK_CREDS)
 image   = Fog::Image::OpenStack.new(OPENSTACK_CREDS)
 network = Fog::Network::OpenStack.new(OPENSTACK_CREDS)
 
-exit OpenStackTaster.new(
-  compute, volume, image, network,
+OpenStackTaster.new(
+  compute, volume, image, network, ENV['OS_NETWORK_REF'],
   SSH_KEYS, LOG_DIR
 ).taste(image_name, settings)

--- a/bin/openstack_taster
+++ b/bin/openstack_taster
@@ -95,7 +95,7 @@ volume  = Fog::Volume::OpenStack.new(OPENSTACK_CREDS)
 image   = Fog::Image::OpenStack.new(OPENSTACK_CREDS)
 network = Fog::Network::OpenStack.new(OPENSTACK_CREDS)
 
-OpenStackTaster.new(
+exit OpenStackTaster.new(
   compute, volume, image, network, ENV['OS_NETWORK_REF'],
   SSH_KEYS, LOG_DIR
 ).taste(image_name, settings)


### PR DESCRIPTION
This includes changes from the `ssh_user` PR because I branched off from it when I first created it. It should shrink after that PR is merged. [Databag PR for environment variables](https://git.osuosl.org/osuosl-chef/data_bags/merge_requests/374)